### PR TITLE
update angular dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,11 +16,11 @@
   ],
   "main": "angular-diff-match-patch.js",
   "dependencies": {
-    "angular": ">= 1.2.0 < 1.4.x",
+    "angular": "^1.2.0",
     "google-diff-match-patch": "0.1.0"
   },
   "devDependencies": {
-    "angular-material": "0.6.1",
-    "angular-mocks": ">= 1.2.0 < 1.4.x"
+    "angular-material": "0.10.0",
+    "angular-mocks": "^1.2.0"
   }
 }


### PR DESCRIPTION
Angular 1.4.1 has been already released.
I tested this library with it, and it seems to work fine.
So there is no need to constrain angular version so strict