### PR TITLE
LinesDiff: options to skip empty lines and long match blocks

### DIFF
--- a/angular-diff-match-patch.js
+++ b/angular-diff-match-patch.js
@@ -5,283 +5,309 @@
 */
 angular.module('diff-match-patch', [])
 	.factory('dmp', ['$window', function dmpFactory($window) {
-		var DiffMatchPatch = $window.diff_match_patch;
+	    var DiffMatchPatch = $window.diff_match_patch;
 
-		var displayType = {
-			INSDEL: 0,
-			LINEDIFF: 1
-		};
+	    var displayType = {
+	        INSDEL: 0,
+	        LINEDIFF: 1
+	    };
 
-		function diffClass(op) {
-			switch (op) {
-				case DIFF_INSERT:
-					return 'ins';
-				case DIFF_DELETE:
-					return 'del';
-				default: // case DIFF_EQUAL:
-					return 'match';
-			}
-		}
+	    function diffClass(op) {
+	        switch (op) {
+	            case DIFF_INSERT:
+	                return 'ins';
+	            case DIFF_DELETE:
+	                return 'del';
+	            case null: // case ...
+	                return 'skip';
+	            default: // case DIFF_EQUAL:
+	                return 'match';
+	        }
+	    }
 
-		function diffSymbol(op) {
-			switch (op) {
-				case DIFF_INSERT:
-					return '+';
-				case DIFF_DELETE:
-					return '-';
-				default: // case DIFF_EQUAL:
-					return ' ';
-			}
-		}
+	    function diffSymbol(op) {
+	        switch (op) {
+	            case DIFF_INSERT:
+	                return '+';
+	            case DIFF_DELETE:
+	                return '-';
+	            default: // case DIFF_EQUAL:
+	                return ' ';
+	        }
+	    }
 
-		function diffTag(op) {
-			switch (op) {
-				case DIFF_INSERT:
-					return 'ins';
-				case DIFF_DELETE:
-					return 'del';
-				default: // case DIFF_EQUAL:
-					return 'span';
-			}
-		}
+	    function diffTag(op) {
+	        switch (op) {
+	            case DIFF_INSERT:
+	                return 'ins';
+	            case DIFF_DELETE:
+	                return 'del';
+	            default: // case DIFF_EQUAL:
+	                return 'span';
+	        }
+	    }
 
-		function diffAttrName(op) {
-			switch (op) {
-				case DIFF_INSERT:
-					return 'insert';
-				case DIFF_DELETE:
-					return 'delete';
-				default: // case DIFF_EQUAL:
-					return 'equal';
-			}
-		}
+	    function diffAttrName(op) {
+	        switch (op) {
+	            case DIFF_INSERT:
+	                return 'insert';
+	            case DIFF_DELETE:
+	                return 'delete';
+	            default: // case DIFF_EQUAL:
+	                return 'equal';
+	        }
+	    }
 
-		function isEmptyObject(o) {
-			return Object.getOwnPropertyNames(o).length === 0;
-		}
+	    function isEmptyObject(o) {
+	        return Object.getOwnPropertyNames(o).length === 0;
+	    }
 
-		function getTagAttrs(options, op, attrs) {
-			var attributes = attrs || {};
-			var tagOptions = {};
-			var attribute;
-			var tagOption;
-			var retVal = [];
+	    function getTagAttrs(options, op, attrs) {
+	        var attributes = attrs || {};
+	        var tagOptions = {};
+	        var attribute;
+	        var tagOption;
+	        var retVal = [];
 
-			if (angular.isDefined(options) && angular.isDefined(options.attrs)) {
-				tagOptions = angular.copy(options.attrs[diffAttrName(op)] || {});
-			}
+	        if (angular.isDefined(options) && angular.isDefined(options.attrs)) {
+	            tagOptions = angular.copy(options.attrs[diffAttrName(op)] || {});
+	        }
 
-			if (isEmptyObject(tagOptions) && isEmptyObject(attributes)) {
-				return '';
-			}
+	        if (isEmptyObject(tagOptions) && isEmptyObject(attributes)) {
+	            return '';
+	        }
 
-			for (attribute in attributes) {
-				if (angular.isDefined(tagOptions[attribute])) {
-					// The attribute defined in attributes should be first
-					tagOptions[attribute] = attributes[attribute] + ' ' + tagOptions[attribute];
-				} else {
-					tagOptions[attribute] = attributes[attribute];
-				}
-			}
+	        for (attribute in attributes) {
+	            if (angular.isDefined(tagOptions[attribute])) {
+	                // The attribute defined in attributes should be first
+	                tagOptions[attribute] = attributes[attribute] + ' ' + tagOptions[attribute];
+	            } else {
+	                tagOptions[attribute] = attributes[attribute];
+	            }
+	        }
 
-			/* eslint guard-for-in: "off" */
-			for (tagOption in tagOptions) {
-				retVal.push(tagOption + '="' + tagOptions[tagOption] + '"');
-			}
-			return ' ' + retVal.join(' ');
-		}
+	        /* eslint guard-for-in: "off" */
+	        for (tagOption in tagOptions) {
+	            retVal.push(tagOption + '="' + tagOptions[tagOption] + '"');
+	        }
+	        return ' ' + retVal.join(' ');
+	    }
 
-		function getHtmlPrefix(op, display, options) {
-			switch (display) {
-				case displayType.LINEDIFF:
-					return '<div class="' + diffClass(op) + '"><span' + getTagAttrs(options, op, {class: 'noselect'}) + '>' + diffSymbol(op) + '</span>';
-				default: // case displayType.INSDEL:
-					return '<' + diffTag(op) + getTagAttrs(options, op) + '>';
-			}
-		}
+	    function getHtmlPrefix(op, display, options) {
+	        switch (display) {
+	            case displayType.LINEDIFF:
+	                return '<div class="' + diffClass(op) + '"><span' + getTagAttrs(options, op, { class: 'noselect' }) + '>' + diffSymbol(op) + '</span>';
+	            default: // case displayType.INSDEL:
+	                return '<' + diffTag(op) + getTagAttrs(options, op) + '>';
+	        }
+	    }
 
-		function getHtmlSuffix(op, display) {
-			switch (display) {
-				case displayType.LINEDIFF:
-					return '</div>';
-				default: // case displayType.INSDEL:
-					return '</' + diffTag(op) + '>';
-			}
-		}
+	    function getHtmlSuffix(op, display) {
+	        switch (display) {
+	            case displayType.LINEDIFF:
+	                return '</div>';
+	            default: // case displayType.INSDEL:
+	                return '</' + diffTag(op) + '>';
+	        }
+	    }
 
-		function createHtmlLines(text, op, options) {
-			var lines = text.split('\n');
-			var y;
-			for (y = 0; y < lines.length; y++) {
-				if (lines[y].length === 0) {
-					continue;
-				}
-				lines[y] = getHtmlPrefix(op, displayType.LINEDIFF, options) + lines[y] + getHtmlSuffix(op, displayType.LINEDIFF);
-			}
-			return lines.join('');
-		}
+	    function createHtmlLines(text, op, options, firstLast) {
+	        var lines = text.split('\n');
+	        var y;
 
-		function createHtmlFromDiffs(diffs, display, options) {
-			var patternAmp = /&/g;
-			var patternLt = /</g;
-			var patternGt = />/g;
-			var x;
-			var html = [];
-			var y;
-			var data;
-			var op;
-			var text;
-			var diffData = diffs;
+	        if (options.attrs.linesAround && op == 0 && lines.length > options.attrs.linesAround * 2) {
+	            var begin = '';
+	            var skip = getHtmlPrefix(null, displayType.LINEDIFF, options) + "&middot;&middot;&middot;" + getHtmlSuffix(null, displayType.LINEDIFF);
+	            var end = '';
 
-			for (x = 0; x < diffData.length; x++) {
-				data = diffData[x][1];
-				diffData[x][1] = data.replace(patternAmp, '&amp;')
-					.replace(patternLt, '&lt;')
-					.replace(patternGt, '&gt;');
-			}
+	            if (firstLast !== true) { // if not matched lines in the beginning of text
+	                begin = lines.slice(0, options.attrs.linesAround).join('\n');
+	                begin = createHtmlLines(begin, op, options);
+	            }
+	            if (firstLast !== false) { // if not matched lines in the end of text
+	                end = lines.slice(-options.attrs.linesAround - 1).join('\n');
+	                end = createHtmlLines(end, op, options);
+	            }
+	            
+	            return begin + skip + end;
+	        }
 
-			for (y = 0; y < diffData.length; y++) {
-				op = diffData[y][0];
-				text = diffData[y][1];
-				if (display === displayType.LINEDIFF) {
-					html[y] = createHtmlLines(text, op, options);
-				} else {
-					html[y] = getHtmlPrefix(op, display, options) + text + getHtmlSuffix(op, display);
-				}
-			}
-			return html.join('');
-		}
+	        for (y = 0; y < lines.length; y++) {
+	            if (lines[y].length === 0) {
+	                continue;
+	            }
+	            lines[y] = getHtmlPrefix(op, displayType.LINEDIFF, options) + lines[y] + getHtmlSuffix(op, displayType.LINEDIFF);
+	        }
+	        return lines.join('');
+	    }
 
-		function assertArgumentsIsStrings(left, right) {
-			return angular.isString(left) && angular.isString(right);
-		}
+	    function createHtmlFromDiffs(diffs, display, options) {
+	        var patternAmp = /&/g;
+	        var patternLt = /</g;
+	        var patternGt = />/g;
+	        var x;
+	        var html = [];
+	        var y;
+	        var data;
+	        var op;
+	        var text;
+	        var diffData = diffs;
 
-		return {
-			createDiffHtml: function createDiffHtml(left, right, options) {
-				var dmp;
-				var diffs;
-				if (assertArgumentsIsStrings(left, right)) {
-					dmp = new DiffMatchPatch();
-					diffs = dmp.diff_main(left, right);
-					return createHtmlFromDiffs(diffs, displayType.INSDEL, options);
-				}
-				return '';
-			},
+	        for (x = 0; x < diffData.length; x++) {
+	            data = diffData[x][1];
+	            diffData[x][1] = data.replace(patternAmp, '&amp;')
+                    .replace(patternLt, '&lt;')
+                    .replace(patternGt, '&gt;');
+	        }
 
-			createProcessingDiffHtml: function createProcessingDiffHtml(left, right, options) {
-				var dmp;
-				var diffs;
-				if (assertArgumentsIsStrings(left, right)) {
-					dmp = new DiffMatchPatch();
-					diffs = dmp.diff_main(left, right);
+	        for (y = 0; y < diffData.length; y++) {
+	            op = diffData[y][0];
+	            text = diffData[y][1];
+	            var firstLast = null;
+	            if (y == 0) firstLast = true;
+	            if (y == diffData.length - 1) firstLast = false;
+	            if (display === displayType.LINEDIFF) {
+	                html[y] = createHtmlLines(text, op, options, firstLast);
+	            } else {
+	                html[y] = getHtmlPrefix(op, display, options) + text + getHtmlSuffix(op, display);
+	            }
+	        }
+	        return html.join('');
+	    }
 
-					if (angular.isDefined(options) && angular.isDefined(options.editCost) && isFinite(options.editCost)) {
-						dmp.Diff_EditCost = options.editCost; // eslint-disable-line camelcase
-					}
+	    function assertArgumentsIsStrings(left, right) {
+	        return angular.isString(left) && angular.isString(right);
+	    }
 
-					dmp.diff_cleanupEfficiency(diffs);
-					return createHtmlFromDiffs(diffs, displayType.INSDEL, options);
-				}
-				return '';
-			},
+	    return {
+	        createDiffHtml: function createDiffHtml(left, right, options) {
+	            var dmp;
+	            var diffs;
+	            if (assertArgumentsIsStrings(left, right)) {
+	                dmp = new DiffMatchPatch();
+	                diffs = dmp.diff_main(left, right);
+	                return createHtmlFromDiffs(diffs, displayType.INSDEL, options);
+	            }
+	            return '';
+	        },
 
-			createSemanticDiffHtml: function createSemanticDiffHtml(left, right, options) {
-				var dmp;
-				var diffs;
-				if (assertArgumentsIsStrings(left, right)) {
-					dmp = new DiffMatchPatch();
-					diffs = dmp.diff_main(left, right);
-					dmp.diff_cleanupSemantic(diffs);
-					return createHtmlFromDiffs(diffs, displayType.INSDEL, options);
-				}
-				return '';
-			},
+	        createProcessingDiffHtml: function createProcessingDiffHtml(left, right, options) {
+	            var dmp;
+	            var diffs;
+	            if (assertArgumentsIsStrings(left, right)) {
+	                dmp = new DiffMatchPatch();
+	                diffs = dmp.diff_main(left, right);
 
-			createLineDiffHtml: function createLineDiffHtml(left, right, options) {
-				var dmp;
-				var chars;
-				var diffs;
-				if (assertArgumentsIsStrings(left, right)) {
-					dmp = new DiffMatchPatch();
-					chars = dmp.diff_linesToChars_(left, right);
-					diffs = dmp.diff_main(chars.chars1, chars.chars2, false);
-					dmp.diff_charsToLines_(diffs, chars.lineArray);
-					return createHtmlFromDiffs(diffs, displayType.LINEDIFF, options);
-				}
-				return '';
-			}
-		};
+	                if (angular.isDefined(options) && angular.isDefined(options.editCost) && isFinite(options.editCost)) {
+	                    dmp.Diff_EditCost = options.editCost; // eslint-disable-line camelcase
+	                }
+
+	                dmp.diff_cleanupEfficiency(diffs);
+	                return createHtmlFromDiffs(diffs, displayType.INSDEL, options);
+	            }
+	            return '';
+	        },
+
+	        createSemanticDiffHtml: function createSemanticDiffHtml(left, right, options) {
+	            var dmp;
+	            var diffs;
+	            if (assertArgumentsIsStrings(left, right)) {
+	                dmp = new DiffMatchPatch();
+	                diffs = dmp.diff_main(left, right);
+	                dmp.diff_cleanupSemantic(diffs);
+	                return createHtmlFromDiffs(diffs, displayType.INSDEL, options);
+	            }
+	            return '';
+	        },
+
+	        createLineDiffHtml: function createLineDiffHtml(left, right, options) {
+	            var dmp;
+	            var chars;
+	            var diffs;
+	            if (assertArgumentsIsStrings(left, right)) {
+	                dmp = new DiffMatchPatch();
+	                chars = dmp.diff_linesToChars_(left, right);
+	                diffs = dmp.diff_main(chars.chars1, chars.chars2, false);
+	                dmp.diff_charsToLines_(diffs, chars.lineArray);
+	                return createHtmlFromDiffs(diffs, displayType.LINEDIFF, options);
+	            }
+	            return '';
+	        }
+	    };
 	}])
 	.directive('diff', ['$compile', 'dmp', function factory($compile, dmp) {
-		var ddo = {
-			scope: {
-				left: '=leftObj',
-				right: '=rightObj',
-				options: '=options'
-			},
-			link: function postLink(scope, iElement) {
-				var listener = function listener() {
-					iElement.html(dmp.createDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
-				};
-				scope.$watch('left', listener);
-				scope.$watch('right', listener);
-			}
-		};
-		return ddo;
+	    var ddo = {
+	        scope: {
+	            left: '=leftObj',
+	            right: '=rightObj',
+	            options: '=options'
+	        },
+	        link: function postLink(scope, iElement) {
+	            var listener = function listener() {
+	                iElement.html(dmp.createDiffHtml(scope.left, scope.right, scope.options));
+	                $compile(iElement.contents())(scope);
+	            };
+	            scope.$watch('left', listener);
+	            scope.$watch('right', listener);
+	        }
+	    };
+	    return ddo;
 	}])
 	.directive('processingDiff', ['$compile', 'dmp', function factory($compile, dmp) {
-		var ddo = {
-			scope: {
-				left: '=leftObj',
-				right: '=rightObj',
-				options: '=options'
-			},
-			link: function postLink(scope, iElement) {
-				var listener = function listener() {
-					iElement.html(dmp.createProcessingDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
-				};
-				scope.$watch('left', listener);
-				scope.$watch('right', listener);
-				scope.$watch('options.editCost', listener, true);
-			}
-		};
-		return ddo;
+	    var ddo = {
+	        scope: {
+	            left: '=leftObj',
+	            right: '=rightObj',
+	            options: '=options'
+	        },
+	        link: function postLink(scope, iElement) {
+	            var listener = function listener() {
+	                iElement.html(dmp.createProcessingDiffHtml(scope.left, scope.right, scope.options));
+	                $compile(iElement.contents())(scope);
+	            };
+	            scope.$watch('left', listener);
+	            scope.$watch('right', listener);
+	            scope.$watch('options.editCost', listener, true);
+	        }
+	    };
+	    return ddo;
 	}])
 	.directive('semanticDiff', ['$compile', 'dmp', function factory($compile, dmp) {
-		var ddo = {
-			scope: {
-				left: '=leftObj',
-				right: '=rightObj',
-				options: '=options'
-			},
-			link: function postLink(scope, iElement) {
-				var listener = function listener() {
-					iElement.html(dmp.createSemanticDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
-				};
-				scope.$watch('left', listener);
-				scope.$watch('right', listener);
-			}
-		};
-		return ddo;
+	    var ddo = {
+	        scope: {
+	            left: '=leftObj',
+	            right: '=rightObj',
+	            options: '=options'
+	        },
+	        link: function postLink(scope, iElement) {
+	            var listener = function listener() {
+	                iElement.html(dmp.createSemanticDiffHtml(scope.left, scope.right, scope.options));
+	                $compile(iElement.contents())(scope);
+	            };
+	            scope.$watch('left', listener);
+	            scope.$watch('right', listener);
+	        }
+	    };
+	    return ddo;
 	}])
 	.directive('lineDiff', ['$compile', 'dmp', function factory($compile, dmp) {
-		var ddo = {
-			scope: {
-				left: '=leftObj',
-				right: '=rightObj',
-				options: '=options'
-			},
-			link: function postLink(scope, iElement) {
-				var listener = function listener() {
-					iElement.html(dmp.createLineDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
-				};
-				scope.$watch('left', listener);
-				scope.$watch('right', listener);
-			}
-		};
-		return ddo;
+	    var ddo = {
+	        scope: {
+	            left: '=leftObj',
+	            right: '=rightObj',
+	            options: '=options'
+	        },
+	        link: function postLink(scope, iElement) {
+	            var listener = function listener() {
+	                if (scope.options && scope.options.attrs.ignoreEmptyLines)
+	                    iElement.html(dmp.createLineDiffHtml(scope.left.replace(/\n\s+\n/g, "\n"), scope.right.replace(/\n\s+\n/g, "\n"), scope.options));
+	                else
+	                    iElement.html(dmp.createLineDiffHtml(scope.left, scope.right, scope.options));
+	                $compile(iElement.contents())(scope);
+	            };
+	            scope.$watch('left', listener);
+	            scope.$watch('right', listener);
+	        }
+	    };
+	    return ddo;
 	}]);

--- a/angular-diff-match-patch.js
+++ b/angular-diff-match-patch.js
@@ -115,7 +115,7 @@ angular.module('diff-match-patch', [])
 	        var lines = text.split('\n');
 	        var y;
 
-	        if (options.attrs.linesAround && op == 0 && lines.length > options.attrs.linesAround * 2) {
+	        if (options && options.attrs && options.attrs.linesAround && op == 0 && lines.length > options.attrs.linesAround * 2) {
 	            var begin = '';
 	            var skip = getHtmlPrefix(null, displayType.LINEDIFF, options) + "&middot;&middot;&middot;" + getHtmlSuffix(null, displayType.LINEDIFF);
 	            var end = '';
@@ -299,7 +299,7 @@ angular.module('diff-match-patch', [])
 	        },
 	        link: function postLink(scope, iElement) {
 	            var listener = function listener() {
-	                if (scope.options && scope.options.attrs.ignoreEmptyLines)
+	                if (scope.options && scope.options.attrs && scope.options.attrs.ignoreEmptyLines)
 	                    iElement.html(dmp.createLineDiffHtml(scope.left.replace(/\n\s+\n/g, "\n"), scope.right.replace(/\n\s+\n/g, "\n"), scope.options));
 	                else
 	                    iElement.html(dmp.createLineDiffHtml(scope.left, scope.right, scope.options));


### PR DESCRIPTION
Example:
```js
        $scope.options = {
            editCost: 4,
            attrs: {
                ignoreEmptyLines: true, // not use empty lines in comparison
                linesAround: 2, // skip long match lines blocks (longer than X lines before/after changes)
                insert: {
                    'data-attr': 'insert',
                    'class': 'text-success' // some bootstrap classes
                },
                delete: {
                    'data-attr': 'delete',
                    'class': 'text-warning'
                },
                equal: {
                    'data-attr': 'equal',
                    'class': 'text-muted'
                }
            }
        };
```

Can produce this results:
![image](https://cloud.githubusercontent.com/assets/3350070/16707448/af79b66c-45d6-11e6-9d13-46433b5cdaa3.png)

Cyan lines with `···` representing loooong blocks of similar lines.

```css
pre div {
    position: relative;
}

pre div:nth-child(2n+1):not(.skip):before {
    content: ' ';
    left: 0px;
    right: 0px;
    top: 0px;
    bottom: 0px;
    position: absolute;
    display: inline-block;
    background-color: rgba(0,0,0,0.03);
}

pre .del {
    background-color: rgba(255,0,0,0.1);
}

pre .ins {
    background-color: rgba(0,255,0,0.1);
}

pre .skip {
    background-color: rgba(0,200,200,0.1);
}
```