### PR TITLE
Add the option to pass in the options to skip angular compiling on the diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ $scope.options = {
 
 `editCost` is specific to `processingDiff` and controls the tolerence for hunk separation.  `attrs` can contain any/all/none of the following: `insert`, `delete`, and `equal` where the properties in those objects represent attributes that get added to the tags.
 
+Another option is to skip angular processing the diff, it's useful when you want to show a diff of a code pre-compiled by angular. The attribute you need to add is called: `skipAngularCompilingOnDiff`. If set to `true`, would skip compiling, otherwise it would compile the diff.
+
 Add some style
 ```css
 .match{

--- a/angular-diff-match-patch.js
+++ b/angular-diff-match-patch.js
@@ -218,7 +218,11 @@ angular.module('diff-match-patch', [])
 			link: function postLink(scope, iElement) {
 				var listener = function listener() {
 					iElement.html(dmp.createDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
+					// If no options given, or, we have been given options and don't want to skip angular compiling
+					// Then compile angular in the diff.
+					if (!scope.options || (scope.options && !scope.options.skipAngularCompilingOnDiff)) {
+						$compile(iElement.contents())(scope);
+					}
 				};
 				scope.$watch('left', listener);
 				scope.$watch('right', listener);
@@ -236,7 +240,11 @@ angular.module('diff-match-patch', [])
 			link: function postLink(scope, iElement) {
 				var listener = function listener() {
 					iElement.html(dmp.createProcessingDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
+					// If no options given, or, we have been given options and don't want to skip angular compiling
+					// Then compile angular in the diff.
+					if (!scope.options || (scope.options && !scope.options.skipAngularCompilingOnDiff)) {
+						$compile(iElement.contents())(scope);
+					}
 				};
 				scope.$watch('left', listener);
 				scope.$watch('right', listener);
@@ -255,7 +263,11 @@ angular.module('diff-match-patch', [])
 			link: function postLink(scope, iElement) {
 				var listener = function listener() {
 					iElement.html(dmp.createSemanticDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
+					// If no options given, or, we have been given options and don't want to skip angular compiling
+					// Then compile angular in the diff.
+					if (!scope.options || (scope.options && !scope.options.skipAngularCompilingOnDiff)) {
+						$compile(iElement.contents())(scope);
+					}
 				};
 				scope.$watch('left', listener);
 				scope.$watch('right', listener);
@@ -273,7 +285,11 @@ angular.module('diff-match-patch', [])
 			link: function postLink(scope, iElement) {
 				var listener = function listener() {
 					iElement.html(dmp.createLineDiffHtml(scope.left, scope.right, scope.options));
-					$compile(iElement.contents())(scope);
+					// If no options given, or, we have been given options and don't want to skip angular compiling
+					// Then compile angular in the diff.
+					if (!scope.options || (scope.options && !scope.options.skipAngularCompilingOnDiff)) {
+						$compile(iElement.contents())(scope);
+					}
 				};
 				scope.$watch('left', listener);
 				scope.$watch('right', listener);

--- a/test/diffmatchpatch-spec.js
+++ b/test/diffmatchpatch-spec.js
@@ -7,6 +7,9 @@ describe('diff-match-patch', function diffMatchPatchDescription() {
 	var multiLineRight = ['I\'m quite adept at funny gags, comedic theory I have read',
 		'From wicked puns and stupid jokes to anvils that drop on your head.'].join('\n');
 	var diffRegex = '<span.*?>hello</span><del.*?> world</del>';
+	var oneLineAngularLeft = '{{1 + 2}} hello world';
+	var oneLineAngularRight = '{{1 + 2}} hello';
+	var angularProcessedDiffRegex = '<span.*?>3 hello</span><del.*?> world</del>';
 
 	beforeEach(module('diff-match-patch'));
 	describe('directive', function directiveDescription() {
@@ -20,6 +23,43 @@ describe('diff-match-patch', function diffMatchPatchDescription() {
 
 		describe('diff', function diffDescription() {
 			var diffHtmlNoOptions = '<div diff left-obj="left" right-obj="right"></div>';
+			var diffHtmlWithOptions = '<div diff left-obj="left" right-obj="right" options="options"></div>';
+
+			it('compile angular tokens in the diff', function makeSureAngularCompiles() {
+				var element = $compile(diffHtmlNoOptions)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>3 hello</ins>'));
+			});
+
+			it('compile angular tokens in the total diff', function singleLineTotal() {
+				var element = $compile(diffHtmlNoOptions)($scope);
+				$scope.left = oneLineAngularLeft;
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp(angularProcessedDiffRegex));
+			});
+
+			it('compile angular tokens in the diff if no flag has given in options', function makeSureAngularCompilesWithoutFlag() {
+				var element = $compile(diffHtmlWithOptions)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.options = {};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>3 hello</ins>'));
+			});
+
+			it('should not compile angular tokens in the diff if the flag has been set', function skipAngularComilingWithFlag() {
+				var element = $compile(diffHtmlWithOptions)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.options = {
+					skipAngularCompilingOnDiff: true
+				};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>{{1 \\+ 2}} hello</ins>'));
+			});
 
 			it('no sides returns empty string', function noSidesEmpty() {
 				var element = $compile(diffHtmlNoOptions)($scope);
@@ -60,8 +100,7 @@ describe('diff-match-patch', function diffMatchPatchDescription() {
 			});
 
 			it('two lines with options returns diff HTML', function twoLineOptionDiff() {
-				var html = '<div diff left-obj="left" right-obj="right" options="options"></div>';
-				var element = $compile(html)($scope);
+				var element = $compile(diffHtmlWithOptions)($scope);
 				var regex = '<span .*?data-attr="equal".*?>hello[\\s\\S]*?</span><del .*?data-attr="delete".*?>wo</del><ins .*?data-attr="insert".*?>f</ins><span .*?data-attr="equal".*?>r</span><del .*?data-attr="delete".*?>l</del><ins .*?data-attr="insert".*?>ien</ins><span .*?data-attr="equal".*?>d</span><ins.*?data-attr="insert".*?>s!</ins>';
 				$scope.left = ['hello', 'world'].join('\n');
 				$scope.right = ['hello', 'friends!'].join('\n');
@@ -88,6 +127,42 @@ describe('diff-match-patch', function diffMatchPatchDescription() {
 			var processingDiffHtml = '<div processing-diff left-obj="left" right-obj="right"></div>';
 			var processingDiffOptionsHtml = '<div processing-diff left-obj="left" right-obj="right" options="options"></div>';
 			var twoLineRegex = '<span.*?>I</span><del.*?> know the kings of England, and I quote</del><ins.*?>\'m quite adept at funny gags, comedic</ins><span.*?> the</span><del.*?> fights historical,</del><ins.*?>ory I have read</ins><span.*?>[\\s\\S]*?From </span><del.*?>Marathon</del><ins.*?>wicked puns and stupid jokes</ins><span.*?> to </span><del.*?>Waterloo, in order categorical</del><ins.*?>anvils that drop on your head</ins><span.*?>.</span>';
+
+			it('compile angular tokens in the diff', function makeSureAngularCompiles() {
+				var element = $compile(processingDiffHtml)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>3 hello</ins>'));
+			});
+
+			it('compile angular tokens in the total diff', function singleLineTotal() {
+				var element = $compile(processingDiffHtml)($scope);
+				$scope.left = oneLineAngularLeft;
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp(angularProcessedDiffRegex));
+			});
+
+			it('compile angular tokens in the diff if no flag has given in options', function makeSureAngularCompilesWithoutFlag() {
+				var element = $compile(processingDiffOptionsHtml)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.options = {};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>3 hello</ins>'));
+			});
+
+			it('should not compile angular tokens in the diff if the flag has been set', function skipAngularComilingWithFlag() {
+				var element = $compile(processingDiffOptionsHtml)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.options = {
+					skipAngularCompilingOnDiff: true
+				};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>{{1 \\+ 2}} hello</ins>'));
+			});
 
 			it('no sides returns empty string', function noSidesEmpty() {
 				var element = $compile(processingDiffHtml)($scope);
@@ -135,6 +210,44 @@ describe('diff-match-patch', function diffMatchPatchDescription() {
 
 		describe('semanticDiff', function semanticDiffDescription() {
 			var semanticDiffHtml = '<div semantic-diff left-obj="left" right-obj="right"></div>';
+			var semanticDiffHtmlWithOptions = '<div semantic-diff left-obj="left" right-obj="right" options="options"></div>';
+
+			it('compile angular tokens in the diff', function makeSureAngularCompiles() {
+				var element = $compile(semanticDiffHtml)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>3 hello</ins>'));
+			});
+
+			it('compile angular tokens in the total diff', function singleLineTotal() {
+				var element = $compile(semanticDiffHtml)($scope);
+				$scope.left = oneLineAngularLeft;
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp(angularProcessedDiffRegex));
+			});
+
+			it('compile angular tokens in the diff if no flag has given in options', function makeSureAngularCompilesWithoutFlag() {
+				var element = $compile(semanticDiffHtmlWithOptions)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.options = {};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>3 hello</ins>'));
+			});
+
+			it('should not compile angular tokens in the diff if the flag has been set', function skipAngularComilingWithFlag() {
+				var element = $compile(semanticDiffHtmlWithOptions)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.options = {
+					skipAngularCompilingOnDiff: true
+				};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('<ins.*?>{{1 \\+ 2}} hello</ins>'));
+			});
+
 			it('no sides returns empty string', function noSidesEmpty() {
 				var element = $compile(semanticDiffHtml)($scope);
 				$scope.$digest();
@@ -170,6 +283,42 @@ describe('diff-match-patch', function diffMatchPatchDescription() {
 			var lineDiffHtml = '<div line-diff left-obj="left" right-obj="right"></div>';
 			var lineDiffOptionHtml = '<div line-diff left-obj="left" right-obj="right" options="options"></div>';
 			var twoLineRegex = '<div class="match .*?"><span class="noselect"> </span>hello</div><div class="del .*?"><span class="noselect">-</span>world</div><div class="ins .*?"><span class="noselect">\\+</span>friends!</div>';
+
+			it('compile angular tokens in the diff', function makeSureAngularCompiles() {
+				var element = $compile(lineDiffHtml)($scope);
+				$scope.left = '';
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('.*?ins.*?</span>3 hello</div>'));
+			});
+
+			it('compile angular tokens in the total diff', function singleLineTotal() {
+				var element = $compile(lineDiffHtml)($scope);
+				$scope.left = oneLineAngularLeft;
+				$scope.right = oneLineAngularRight;
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('.*?-</span>3 hello world.*?\\+</span>3 hello.*?'));
+			});
+
+			it('compile angular tokens in the diff if no flag has given in options', function makeSureAngularCompilesWithoutFlag() {
+				var element = $compile(lineDiffOptionHtml)($scope);
+				$scope.left = oneLineAngularLeft;
+				$scope.right = oneLineAngularRight;
+				$scope.options = {};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('.*?-</span>3 hello world.*?\\+</span>3 hello.*?'));
+			});
+
+			it('should not compile angular tokens in the diff if the flag has been set', function skipAngularComilingWithFlag() {
+				var element = $compile(lineDiffOptionHtml)($scope);
+				$scope.left = oneLineAngularLeft;
+				$scope.right = oneLineAngularRight;
+				$scope.options = {
+					skipAngularCompilingOnDiff: true
+				};
+				$scope.$digest();
+				expect(element.html()).toMatch(new RegExp('.*?-</span>{{1 \\+ 2}} hello world.*?\\+</span>{{1 \\+ 2}} hello.*?'));
+			});
 
 			it('no sides returns empty string', function noSidesEmpty() {
 				var element = $compile(lineDiffHtml)($scope);


### PR DESCRIPTION
Hi,

This is something I encountered when I used your angular wrapper for diff-match-patch. It would automatically compile the code that I was displaying for my users. 

In my case I displayed a diff with a template that contained double curly brackets (code).

So I've extended your component to include the option to skip the angular compiling on the diff. Works like a charm!