### PR TITLE
Remove extraneous globals

### DIFF
--- a/angular-diff-match-patch.js
+++ b/angular-diff-match-patch.js
@@ -9,7 +9,6 @@ angular.module('diff-match-patch', [])
 
 		var DIFF_INSERT = DiffMatchPatch.DIFF_INSERT;
 		var DIFF_DELETE = DiffMatchPatch.DIFF_DELETE;
-		var DIFF_EQUAL = DiffMatchPatch.DIFF_EQUAL;
 
 		var displayType = {
 			INSDEL: 0,

--- a/angular-diff-match-patch.js
+++ b/angular-diff-match-patch.js
@@ -6,6 +6,11 @@
 angular.module('diff-match-patch', [])
 	.factory('dmp', ['$window', function ($window) {
 		var DiffMatchPatch = $window.diff_match_patch;
+
+		var DIFF_INSERT = DiffMatchPatch.DIFF_INSERT;
+		var DIFF_DELETE = DiffMatchPatch.DIFF_DELETE;
+		var DIFF_EQUAL = DiffMatchPatch.DIFF_EQUAL;
+
 		var displayType = {
 			INSDEL: 0,
 			LINEDIFF: 1


### PR DESCRIPTION
Streamlines fix for #27.

After this change, only single function (DiffMatchPatch) must be
exposed/provided when using WebPack.