### PR TITLE
[fix] minimize global usage for use with/without package manager

### DIFF
--- a/angular-diff-match-patch.js
+++ b/angular-diff-match-patch.js
@@ -4,8 +4,14 @@
  @license: MIT
 */
 angular.module('diff-match-patch', [])
-	.factory('dmp', ['$window', function ($window) {
-		var DiffMatchPatch = $window.diff_match_patch;
+	.constant('DiffMatchPatch', diff_match_patch)
+	.factory('DIFF_INSERT', ['DiffMatchPatch', function (DiffMatchPatch) {
+		return DiffMatchPatch.DIFF_INSERT === undefined ? DIFF_INSERT : DiffMatchPatch.DIFF_INSERT;
+	}])
+	.factory('DIFF_DELETE', ['DiffMatchPatch', function (DiffMatchPatch) {
+		return DiffMatchPatch.DIFF_DELETE === undefined ? DIFF_DELETE : DiffMatchPatch.DIFF_DELETE;
+	}])
+	.factory('dmp', ['DiffMatchPatch', 'DIFF_INSERT', 'DIFF_DELETE', function (DiffMatchPatch, DIFF_INSERT, DIFF_DELETE) {
 		var displayType = {
 			INSDEL: 0,
 			LINEDIFF: 1

--- a/test/diffmatchpatch-spec.js
+++ b/test/diffmatchpatch-spec.js
@@ -12,6 +12,21 @@ describe('diff-match-patch', function () {
 	var angularProcessedDiffRegex = '<span.*?>3 hello</span><del.*?> world</del>';
 
 	beforeEach(module('diff-match-patch'));
+	describe('DIFF_INSERT and DIFF_DELETE factories', function () {
+		var DIFF_INSERT;
+		var DIFF_DELETE;
+
+		beforeEach(inject(function (_DIFF_INSERT_, _DIFF_DELETE_) {
+			DIFF_INSERT = _DIFF_INSERT_;
+			DIFF_DELETE = _DIFF_DELETE_;
+		}));
+
+		it('are defined', function () {
+			expect(DIFF_INSERT).toBeDefined();
+			expect(DIFF_DELETE).toBeDefined();
+		});
+	});
+
 	describe('directive', function () {
 		var $scope;
 		var $compile;


### PR DESCRIPTION
= minimize usage of globals within package for ease of use with package managers such as webpack
= avoid use of $window in favor of canonical method for bringing in globals via angular.constant
= preserve backwards-compatibility for users not using a package manager
= add tests to ensure globals are defined whether pulled in with/without a package manager

Usage with webpack is as follows (see https://webpack.js.org/guides/shimming/)
```
  config.plugins = [
    new webpack.ProvidePlugin({
      diff_match_patch: 'diff-match-patch'
    }),
  ];
```
